### PR TITLE
fix: Make ENV var needed for next.config.mjs available during docker build

### DIFF
--- a/docker/wallet-frontend-only/Dockerfile
+++ b/docker/wallet-frontend-only/Dockerfile
@@ -5,6 +5,8 @@ RUN pnpm add typescript tslib
 WORKDIR /opt/wallet/frontend
 
 COPY . .
+
+ARG NEXT_PUBLIC_AGENT_BASE_URL
 RUN pnpm install -r
 RUN pnpm build
 

--- a/docker/wallet-frontend-only/docker-compose.frontend-only.yml
+++ b/docker/wallet-frontend-only/docker-compose.frontend-only.yml
@@ -14,5 +14,6 @@ services:
       args:
         progress: plain
         no-cache: true
+        NEXT_PUBLIC_AGENT_BASE_URL:
     ports:
       - "3001:3001"


### PR DESCRIPTION
Frontend docker compose build would fail with:
```
12.13 `destination` does not start with `/`, `http://`, or `https://` for route {"source":"/.well-known/jwks/:path*","destination":"undefined/.well-known/jwks/:path*"}
12.13
12.13
12.13 Error: Invalid rewrite found
```

This fixes that by making the ENV var available during build, using ARG.