### PR TITLE
feat: Add package manager to npm package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,5 +119,6 @@
       "@veramo/credential-w3c@4.2.0": "patches/@veramo__credential-w3c@4.2.0.patch",
       "typeorm@0.3.20": "patches/typeorm@0.3.20.patch"
     }
-  }
+  },
+  "packageManager": "pnpm@9.7.0+sha512.dc09430156b427f5ecfc79888899e1c39d2d690f004be70e05230b72cb173d96839587545d09429b55ac3c429c801b4dc3c0e002f653830a420fa2dd4e3cf9cf"
 }


### PR DESCRIPTION
This ensures all devs use pnpm and use the same version. The README explains we must use pnpm (but not the version).
It picks a recent stable version and pins that.
Other devs running other versions will now get an error.

Running a recent pnpm version will add this attribute. So if not added now, a future commit may add this accidentally or devs will need to ignore and revert this all the time.

This increases reproducability of builds