### PR TITLE
fix: Untangle the DB_TYPE env var logic

### DIFF
--- a/packages/agent/.env.example
+++ b/packages/agent/.env.example
@@ -14,8 +14,10 @@ DB_CONNECTION_NAME=default
 # You can find instructions on how to self-host a Supabase deployment here: https://supabase.com/docs/guides/self-hosting
 # You must inform below the DB connection specs. Either use the URL (more flexible), or use DB_HOST and DB_PORT.
 # You can also include username and password: postgresql://user:password:5432/vc-issuer-db
-DB_TYPE="sqlite"
-DB_URL="postgresql://postgres:your-super-secret-and-long-postgres-password@127.0.0.1:5432/postgres"
+#
+# NOTE: DB_TYPE Must be 'postgres' and not 'postgresql'. It cannot be anything else.
+DB_TYPE="postgres"
+DB_URL="postgres://postgres:your-super-secret-and-long-postgres-password@127.0.0.1:5432/postgres"
 #DB_DATABASE_NAME=postgres
 #DB_USERNAME=postgres
 #DB_PASSWORD=your-super-secret-and-long-postgres-password

--- a/packages/agent/src/environment-vars.ts
+++ b/packages/agent/src/environment-vars.ts
@@ -28,6 +28,7 @@ const toBoolean = (value: string | undefined, defaultValue?: boolean): boolean =
  * so the rest of the code doesn't have to know the exact environment values
  */
 export const ENV_VAR_PREFIX = process.env.ENV_VAR_PREFIX ?? ''
+export const DB_TYPE = process.env.DB_TYPE ?? (() => { throw new Error('DB_TYPE is required') })();
 export const DB_URL = env('DB_URL', ENV_VAR_PREFIX) // Using DB_URL is optional
 export const DB_HOST = env('DB_HOST', ENV_VAR_PREFIX)
 export const DB_PORT = env('DB_PORT', ENV_VAR_PREFIX)
@@ -41,28 +42,6 @@ export const DB_CONNECTION_NAME = env('DB_CONNECTION_NAME', ENV_VAR_PREFIX) ?? '
 export const DB_DATABASE_NAME = env('DB_DATABASE_NAME', ENV_VAR_PREFIX) ?? 'web-wallet-agent'
 export const DB_CACHE_ENABLED = env('DB_CACHE_ENABLED', ENV_VAR_PREFIX) ?? 'true'
 export const DB_ENCRYPTION_KEY = env('DB_ENCRYPTION_KEY', ENV_VAR_PREFIX) ?? '29739248cad1bd1a0fc4d9b75cd4d2990de535baf5caadfdf8d8f86664aa830c'
-
-let dbType = env('DB_TYPE', ENV_VAR_PREFIX)
-if (!dbType) {
-    if (DB_URL) {
-        if (DB_URL.includes('sqlite')) {
-            dbType = 'sqlite'
-        } else if (DB_URL.startsWith('http') || DB_URL.startsWith('postgres')) {
-            dbType = 'postgres'
-        } else {
-            dbType = 'postgres'
-        }
-    }
-}
-if (!dbType) {
-    if (DB_HOST || DB_PORT) {
-        dbType = 'postgres'
-    }
-} else if (dbType.toLowerCase().includes('postgres')) {
-    dbType = 'postgres'
-}
-export const DB_TYPE = dbType ?? 'postgres'
-process.env[`${ENV_VAR_PREFIX}${DB_TYPE}`] = DB_TYPE // make sure we sync back in case we did not have it above
 
 export const INTERNAL_HOSTNAME_OR_IP = env('INTERNAL_HOSTNAME_OR_IP', ENV_VAR_PREFIX) ?? env('HOSTNAME', ENV_VAR_PREFIX) ?? '0.0.0.0'
 export const INTERNAL_PORT = env('PORT', ENV_VAR_PREFIX) ? Number.parseInt(env('PORT', ENV_VAR_PREFIX)!) : 5000


### PR DESCRIPTION
This logic caused issues when running:

- The defaults in .env.example are wrong.
- The logic sets the DB_TYPE var based on the DB_URL. But this var is not required nor documented. Nor edge-cases like "psql://" etc etc are covered.
- Just enforcing DB_TYPE is much easier.
- We don't support anything else then postgres (and not postgresql, as the error in our typeOrmDateTime says!) so there's no need for logic to support other database types anyway.
- We must set DB_TYPE, because libs like typeOrmDateTime read it from process.env on their own, and not from passed in config. So these libs require this ENV var to be present. So we cannot simply hardcoded it.